### PR TITLE
Remove `ephemeral` property from `AppInfo`

### DIFF
--- a/ios/PassageReactNativeExtensions.swift
+++ b/ios/PassageReactNativeExtensions.swift
@@ -81,7 +81,6 @@ internal extension AppInfo {
             "allowedIdentifier": allowedIdentifier,
             "authFallbackMethod": authFallbackMethod?.rawValue,
             "authOrigin": authOrigin,
-            "ephemeral": ephemeral,
             "id": id,
             "loginURL": loginURL,
             "name": name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passageidentity/passage-react-native",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/passage-react-native.podspec
+++ b/passage-react-native.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
 
-  s.dependency 'Passage', '1.1.6'
+  s.dependency 'Passage', '1.1.7'
   s.platform = :ios, '16.0'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.


### PR DESCRIPTION
Includes updating iOS SDK dependency from 1.1.6 to 1.1.7.