### PR TITLE
Update AppInfo type with allowedAuthMethods

### DIFF
--- a/change/@passageidentity-passage-react-native-0077a247-375b-4aa4-a0eb-938fffb6b6c9.json
+++ b/change/@passageidentity-passage-react-native-0077a247-375b-4aa4-a0eb-938fffb6b6c9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated appInfo type with new allowedAuthMethods property",
+  "packageName": "@passageidentity/passage-react-native",
+  "email": "kevin.flanagan@passage.id",
+  "dependentChangeType": "patch"
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -96,6 +96,9 @@ export enum RequiredIdentifier {
 
 export type PassageAppInfo = {
   allowedIdentifier: Identifier;
+  /**
+   * @deprecated Check the allowedAuthMethods property for the full list of supported authentication methods and their configurations.
+   */
   authFallbackMethod: AllowedFallbackAuth;
   authOrigin: string;
   id: string;
@@ -106,6 +109,11 @@ export type PassageAppInfo = {
   requireIdentifierVerification: boolean;
   sessionTimeoutLength: number;
   userMetadataSchema: Array<PassageAppUserMetadataSchema> | null;
+  allowedAuthMethods: {
+    passkeys?: Record<string, never>;
+    otp?: EmailAndSMSAuthMethod;
+    magicLink?: EmailAndSMSAuthMethod;
+  }
 };
 
 export type PassageAppUserMetadataSchema = {
@@ -116,6 +124,18 @@ export type PassageAppUserMetadataSchema = {
   registration: boolean;
   type: string;
 };
+
+export type EmailAndSMSAuthMethod = {
+  ttl: number;
+  ttl_display_unit: DisplayUnit;
+}
+
+export enum DisplayUnit {
+  Seconds = 's',
+  Minutes = 'm',
+  Hours = 'h',
+  Days = 'd',
+}
 
 type RegisterWithPasskey = (identifier: string) => Promise<AuthResult>;
 type LoginWithPasskey = () => Promise<AuthResult>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -109,7 +109,7 @@ export type PassageAppInfo = {
   requireIdentifierVerification: boolean;
   sessionTimeoutLength: number;
   userMetadataSchema: Array<PassageAppUserMetadataSchema> | null;
-  allowedAuthMethods: {
+  authMethods: {
     passkeys?: Record<string, never>;
     otp?: EmailAndSMSAuthMethod;
     magicLink?: EmailAndSMSAuthMethod;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -97,7 +97,7 @@ export enum RequiredIdentifier {
 export type PassageAppInfo = {
   allowedIdentifier: Identifier;
   /**
-   * @deprecated Check the allowedAuthMethods property for the full list of supported authentication methods and their configurations.
+   * @deprecated Check the authMethods property for the full list of supported authentication methods and their configurations.
    */
   authFallbackMethod: AllowedFallbackAuth;
   authOrigin: string;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -113,7 +113,7 @@ export type PassageAppInfo = {
     passkeys?: Record<string, never>;
     otp?: EmailAndSMSAuthMethod;
     magicLink?: EmailAndSMSAuthMethod;
-  }
+  };
 };
 
 export type PassageAppUserMetadataSchema = {
@@ -128,7 +128,7 @@ export type PassageAppUserMetadataSchema = {
 export type EmailAndSMSAuthMethod = {
   ttl: number;
   ttl_display_unit: DisplayUnit;
-}
+};
 
 export enum DisplayUnit {
   Seconds = 's',


### PR DESCRIPTION
As part of the new response from the Passage service, the full list of enabled authentication methods will be included in the app info endpoint. This PR updates the type information for the appInfo response and marks the old fields as deprecated.