### PR TITLE
Add `AppInfo.authMethods` mapping from iOS structs.

### DIFF
--- a/change/@passageidentity-passage-react-native-3a720931-6df3-48eb-b954-be482da63068.json
+++ b/change/@passageidentity-passage-react-native-3a720931-6df3-48eb-b954-be482da63068.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Add `AppInfo.authMethods` mapping from iOS structs.",
+  "packageName": "@passageidentity/passage-react-native",
+  "email": "rickycpadilla@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/ios/PassageReactNativeExtensions.swift
+++ b/ios/PassageReactNativeExtensions.swift
@@ -90,7 +90,8 @@ internal extension AppInfo {
             "requireEmailVerification": requireEmailVerification,
             "requireIdentifierVerification": requireIdentifierVerification,
             "sessionTimeoutLength": sessionTimeoutLength,
-            "userMetadataSchema": userMetadataSchema?.map { $0.toDictionary() }
+            "userMetadataSchema": userMetadataSchema?.map { $0.toDictionary() },
+            "authMethods": authMethods?.toDictionary(),
         ]
         return appInfoDict
     }
@@ -119,4 +120,19 @@ internal extension UserMetadataSchema {
         return dictToJsonString(toDictionary())
     }
     
+}
+
+internal extension AuthMethods {
+    func toDictionary() -> [String: Any] {
+        var dict: [String : Any] = [
+            "passkeys": passkeys == nil ? nil : [:] as [String: String],
+            "otp": otp == nil ? nil : ["ttl": otp?.ttl, "ttlDisplayUnit": otp?.ttlDisplayUnit?.rawValue],
+            "magicLink": magicLink == nil ? nil : ["ttl": magicLink?.ttl, "ttlDisplayUnit": magicLink?.ttlDisplayUnit?.rawValue],
+        ]
+        return dict
+    }
+   
+    func toJsonString() -> String {
+        return dictToJsonString(toDictionary())
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passageidentity/passage-react-native",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
This change is needed in order for the TypeScript code to pick up the new `authMethods` property.

We can't use the default Swift encoder because it will map the properties back to snake case.