### PR TITLE
Social auth

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.2.1"
+    classpath "com.android.tools.build:gradle:7.2.2"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
@@ -75,7 +75,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation "id.passage.android:passage:1.5.1"
+  implementation "id.passage.android:passage:1.6.0"
   implementation "com.google.code.gson:gson:2.9.0"
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 PassageReactNative_kotlinVersion=1.7.0
 PassageReactNative_minSdkVersion=21
 PassageReactNative_targetSdkVersion=31
-PassageReactNative_compileSdkVersion=31
+PassageReactNative_compileSdkVersion=34
 PassageReactNative_ndkversion=21.4.7075529

--- a/android/src/main/java/com/passagereactnative/PassageReactNativeModule.kt
+++ b/android/src/main/java/com/passagereactnative/PassageReactNativeModule.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import com.google.gson.Gson
 import id.passage.android.Passage
+import id.passage.android.PassageSocialConnection
 import id.passage.android.PassageToken
 import id.passage.android.exceptions.AddDevicePasskeyCancellationException
 import id.passage.android.exceptions.LoginWithPasskeyCancellationException
@@ -196,20 +197,20 @@ class PassageReactNativeModule(reactContext: ReactApplicationContext) :
   // region SOCIAL METHODS
   @ReactMethod
   fun authorizeWith(connection: String, promise: Promise) {
-    CoroutineScope(Dispatchers.IO).launch {
-      try {
-
-      } catch (e: Exception) {
-        promise.reject("SOCIAL_AUTH_ERROR", e.message, e)
-      }
-    }
+    val validConnection = PassageSocialConnection.values()
+      .firstOrNull { it.value == connection }
+        ?: return promise.reject("SOCIAL_AUTH_ERROR", "Invalid connection type")
+    passage.authorizeWith(validConnection)
+    promise.resolve(null)
   }
 
   @ReactMethod
   fun finishSocialAuthentication(authCode: String, promise: Promise) {
     CoroutineScope(Dispatchers.IO).launch {
       try {
-
+        val authResult = passage.finishSocialAuthentication(authCode)
+        val jsonString = Gson().toJson(authResult)
+        promise.resolve(jsonString)
       } catch (e: Exception) {
         promise.reject("SOCIAL_AUTH_ERROR", e.message, e)
       }

--- a/android/src/main/java/com/passagereactnative/PassageReactNativeModule.kt
+++ b/android/src/main/java/com/passagereactnative/PassageReactNativeModule.kt
@@ -193,6 +193,31 @@ class PassageReactNativeModule(reactContext: ReactApplicationContext) :
 
   // endregion
 
+  // region SOCIAL METHODS
+  @ReactMethod
+  fun authorizeWith(connection: String, promise: Promise) {
+    CoroutineScope(Dispatchers.IO).launch {
+      try {
+
+      } catch (e: Exception) {
+        promise.reject("SOCIAL_AUTH_ERROR", e.message, e)
+      }
+    }
+  }
+
+  @ReactMethod
+  fun finishSocialAuthentication(authCode: String, promise: Promise) {
+    CoroutineScope(Dispatchers.IO).launch {
+      try {
+
+      } catch (e: Exception) {
+        promise.reject("SOCIAL_AUTH_ERROR", e.message, e)
+      }
+    }
+  }
+
+  // endregion
+
   // region TOKEN METHODS
   @ReactMethod
   fun getAuthToken(promise: Promise) {

--- a/change/@passageidentity-passage-react-native-5bdb942c-d2f2-43b0-8f9b-94a9ec45198e.json
+++ b/change/@passageidentity-passage-react-native-5bdb942c-d2f2-43b0-8f9b-94a9ec45198e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Added Social Login functionality.",
+  "packageName": "@passageidentity/passage-react-native",
+  "email": "rickycpadilla@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/ios/PassageReactNative.m
+++ b/ios/PassageReactNative.m
@@ -49,6 +49,11 @@ RCT_EXTERN_METHOD(getMagicLinkStatus:(NSString *)magicLinkId
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 
+// MARK: - Social Auth Methods
+RCT_EXTERN_METHOD(aurhorizeWith:(NSString *)connection
+                  withResolver:(RCTPromiseResolveBlock)resolve
+                  withRejecter:(RCTPromiseRejectBlock)reject);
+
 // MARK: - Token Methods
 RCT_EXTERN_METHOD(getAuthToken:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);

--- a/ios/PassageReactNative.m
+++ b/ios/PassageReactNative.m
@@ -50,7 +50,7 @@ RCT_EXTERN_METHOD(getMagicLinkStatus:(NSString *)magicLinkId
                   withRejecter:(RCTPromiseRejectBlock)reject);
 
 // MARK: - Social Auth Methods
-RCT_EXTERN_METHOD(aurhorizeWith:(NSString *)connection
+RCT_EXTERN_METHOD(authorizeWith:(NSString *)connection
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 

--- a/ios/PassageReactNative.swift
+++ b/ios/PassageReactNative.swift
@@ -200,6 +200,32 @@ class PassageReactNative: NSObject {
         }
     }
     
+    // MARK: - Social Methods
+    
+    @objc(aurhorizeWith:withResolver:withRejecter:)
+    func aurhorizeWith(
+        connection: String,
+        resolve: @escaping RCTPromiseResolveBlock,
+        reject: @escaping RCTPromiseRejectBlock
+    ) {
+        Task {
+            do {
+                guard let safeConnection = PassageSocialConnection(rawValue: connection) else {
+                    reject("SOCIAL_AUTH_ERROR", "Invalid connection.", nil)
+                    return
+                }
+                guard let window = UIApplication.shared.delegate?.window else {
+                    reject("SOCIAL_AUTH_ERROR", "Could not access app window.", nil)
+                    return
+                }
+                let authResult = try await passage.authorize(with: safeConnection, in: window)
+                resolve(authResult.toJsonString())
+            } catch {
+                reject("SOCIAL_AUTH_ERROR", "\(error)", nil)
+            }
+        }
+    }
+    
     // MARK: - Token Methods
     
     @objc(getAuthToken:withRejecter:)

--- a/ios/PassageReactNative.swift
+++ b/ios/PassageReactNative.swift
@@ -202,7 +202,7 @@ class PassageReactNative: NSObject {
     
     // MARK: - Social Methods
     
-    @objc(aurhorizeWith:withResolver:withRejecter:)
+    @objc(authorizeWith:withResolver:withRejecter:)
     func authorizeWith(
         connection: String,
         resolve: @escaping RCTPromiseResolveBlock,
@@ -214,7 +214,7 @@ class PassageReactNative: NSObject {
                     reject("SOCIAL_AUTH_ERROR", "Invalid connection.", nil)
                     return
                 }
-                guard let window = UIApplication.shared.delegate?.window else {
+                guard let window = await UIApplication.shared.delegate?.window ?? nil else {
                     reject("SOCIAL_AUTH_ERROR", "Could not access app window.", nil)
                     return
                 }

--- a/ios/PassageReactNative.swift
+++ b/ios/PassageReactNative.swift
@@ -203,7 +203,7 @@ class PassageReactNative: NSObject {
     // MARK: - Social Methods
     
     @objc(aurhorizeWith:withResolver:withRejecter:)
-    func aurhorizeWith(
+    func authorizeWith(
         connection: String,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passageidentity/passage-react-native",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@passageidentity/passage-react-native",
   "version": "0.5.0",
-  "description": "test",
+  "description": "Native passkey authentication for your React Native app",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
   "types": "lib/typescript/index.d.ts",

--- a/passage-react-native.podspec
+++ b/passage-react-native.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
 
-  s.dependency 'Passage', '1.4.0'
+  s.dependency 'Passage', '1.5.0'
   s.platform = :ios, '16.0'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -395,7 +395,7 @@ class Passage {
             Linking.removeAllListeners('url');
             const parsedUrl = new URL(url);
             const queryParams = new URLSearchParams(parsedUrl.search);
-            const authCode = queryParams.get('authCode');
+            const authCode = queryParams.get('code');
             const result = await PassageReactNative.finishSocialAuthentication(
               authCode
             );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -374,7 +374,7 @@ class Passage {
   /**
    * Authorizes user via a supported third-party social provider.
    * @param {SocialConnection} connection The Social connection to use for authorization
-   * @returns {Promise<AuthResult | null>} A data object that includes a redirect URL and saves the authorization token and (optional) refresh token securely to device.
+   * @returns {Promise<AuthResult>} A data object that includes a redirect URL and saves the authorization token and (optional) refresh token securely to device.
    * @throws {PassageError}
    */
   authorizeWith: AuthorizeWith = async (

--- a/src/utils/waitForDeepLinkQueryValue.ts
+++ b/src/utils/waitForDeepLinkQueryValue.ts
@@ -1,0 +1,54 @@
+import { AppState, Linking } from 'react-native';
+
+const getUrlParamValue = (url: string, param: string): string | null => {
+  const queryString = url.split('?')[1];
+  const queryParams = queryString
+    ? queryString.split('&').reduce((acc, current) => {
+        const [key, value] = current.split('=');
+        if (key && value) {
+          acc[key] = decodeURIComponent(value);
+        }
+        return acc;
+      }, {} as Record<string, string>)
+    : {};
+  return queryParams[param] || null;
+};
+
+/**
+ * Call this function when expecting a redirect into the application when the app has
+ * become inactive or backgrounded.
+ *
+ * Note that this function works best in a "singleTask" Android app.
+ *
+ * @param parameter The parameter of the value to return from Deep Link.
+ * @returns string
+ * @throws
+ */
+export const waitForDeepLinkQueryValue = async (parameter: string) => {
+  return new Promise(async (resolve, reject) => {
+    // We need to listen for a Deep Link url event, and attempt to extract the parameter
+    // from the redirect url.
+    const linkingListener = Linking.addEventListener('url', async (event) => {
+      appStateListener.remove();
+      linkingListener.remove();
+      const { url } = event;
+      const value = getUrlParamValue(url, parameter);
+      if (!value) {
+        return reject(new Error('Missing query parameter in redirect url.'));
+      }
+      resolve(value);
+    });
+    // We need to listen for an AppState change event in the case that the user returns to
+    // the app without having been redirected.
+    // Note that appStateListener will NEVER be triggered before linkingListener.
+    const appStateListener = AppState.addEventListener(
+      'change',
+      (nextAppState) => {
+        if (nextAppState !== 'active') return;
+        appStateListener.remove();
+        linkingListener.remove();
+        reject(new Error('Operation canceled.'));
+      }
+    );
+  });
+};


### PR DESCRIPTION
## What's new

Users can now log in to a Passage app using Social Login.
Upon successful login using `passage.authorizeWith`, Passage React Native will save the user's tokens to device.

## Example code

```ts
// This will open up the native Sign in with Apple UI on iOS, or a secure web view on Android:
await passage.authorizeWith(SocialConnection.Apple)

// These will open up a secure web view for Google and GitHub sign in on both iOS and Android:
await passage.authorizeWith(SocialConnection.Google)
await passage.authorizeWith(SocialConnection.GitHub)
```