### PR TITLE
New passkey auth methods

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
-  implementation "id.passage.android:passage:1.6.1"
+  implementation "id.passage.android:passage:1.7.0"
   implementation "com.google.code.gson:gson:2.9.0"
 }
 

--- a/android/src/main/java/com/passagereactnative/PassageReactNativeModule.kt
+++ b/android/src/main/java/com/passagereactnative/PassageReactNativeModule.kt
@@ -64,10 +64,10 @@ class PassageReactNativeModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun loginWithPasskey(promise: Promise) {
+  fun loginWithPasskey(identifier: String?, promise: Promise) {
     CoroutineScope(Dispatchers.IO).launch {
       try {
-        val authResult = passage.loginWithPasskey()
+        val authResult = passage.loginWithPasskey(identifier)
         val jsonString = Gson().toJson(authResult)
         promise.resolve(jsonString)
       } catch (e: Exception) {

--- a/ios/PassageReactNative.m
+++ b/ios/PassageReactNative.m
@@ -11,7 +11,8 @@ RCT_EXTERN_METHOD(registerWithPasskey:(NSString *)identifier
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 
-RCT_EXTERN_METHOD(loginWithPasskey:(RCTPromiseResolveBlock)resolve
+RCT_EXTERN_METHOD(loginWithPasskey:(nullable NSString *)identifier
+                  withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 
 

--- a/ios/PassageReactNative.m
+++ b/ios/PassageReactNative.m
@@ -8,6 +8,7 @@ RCT_EXTERN_METHOD(initWithAppId:(NSString *)appId
 
 // MARK: - Passkey Methods
 RCT_EXTERN_METHOD(registerWithPasskey:(NSString *)identifier
+                  withOptionsDictionary:( nullable NSDictionary *)optionsDictionary
                   withResolver:(RCTPromiseResolveBlock)resolve
                   withRejecter:(RCTPromiseRejectBlock)reject);
 

--- a/ios/PassageReactNative.swift
+++ b/ios/PassageReactNative.swift
@@ -24,9 +24,10 @@ class PassageReactNative: NSObject {
     
     // MARK: - Passkey Methods
     
-    @objc(registerWithPasskey:withResolver:withRejecter:)
+    @objc(registerWithPasskey:withOptionsDictionary:withResolver:withRejecter:)
     func registerWithPasskey(
         identifier: String,
+        optionsDictionary: NSDictionary?,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
@@ -36,7 +37,13 @@ class PassageReactNative: NSObject {
         }
         Task {
             do {
-                let authResult = try await passage.registerWithPasskey(identifier: identifier)
+                var passkeyCreationOptions: PasskeyCreationOptions?
+                if let authenticatorAttachmentString = optionsDictionary?["authenticatorAttachment"] as? String,
+                   let authenticatorAttachment = AuthenticatorAttachment(rawValue: authenticatorAttachmentString)
+                {
+                    passkeyCreationOptions = PasskeyCreationOptions(authenticatorAttachment: authenticatorAttachment)
+                }
+                let authResult = try await passage.registerWithPasskey(identifier: identifier, options: passkeyCreationOptions)
                 resolve(authResult.toJsonString())
             } catch PassageASAuthorizationError.canceled {
                 reject("USER_CANCELLED", "User cancelled interaction", nil)

--- a/ios/PassageReactNative.swift
+++ b/ios/PassageReactNative.swift
@@ -46,8 +46,9 @@ class PassageReactNative: NSObject {
         }
     }
     
-    @objc(loginWithPasskey:withRejecter:)
+    @objc(loginWithPasskey:withResolver:withRejecter:)
     func loginWithPasskey(
+        identifier: String?,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) -> Void {
@@ -57,7 +58,7 @@ class PassageReactNative: NSObject {
         }
         Task {
             do {
-                let authResult = try await passage.loginWithPasskey()
+                let authResult = try await passage.loginWithPasskey(identifier: identifier)
                 resolve(authResult.toJsonString())
             } catch PassageASAuthorizationError.canceled {
                 reject("USER_CANCELLED", "User cancelled interaction", nil)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@passageidentity/passage-react-native",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Native passkey authentication for your React Native app",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/passage-react-native.podspec
+++ b/passage-react-native.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
 
-  s.dependency 'Passage', '1.5.1'
+  s.dependency 'Passage', '1.6.0'
   s.platform = :ios, '16.0'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -132,6 +132,16 @@ export type EmailAndSMSAuthMethod = {
   ttl_display_unit: DisplayUnit;
 };
 
+export enum AuthenticatorAttachment {
+  Platform = 'platform',
+  CrossPlatform = 'cross-platform',
+  Any = 'any',
+}
+
+export interface PasskeyCreationOptions {
+  authenticatorAttachment?: AuthenticatorAttachment;
+}
+
 export enum DisplayUnit {
   Seconds = 's',
   Minutes = 'm',
@@ -145,7 +155,10 @@ export enum SocialConnection {
   Google = 'google',
 }
 
-type RegisterWithPasskey = (identifier: string) => Promise<AuthResult>;
+type RegisterWithPasskey = (
+  identifier: string,
+  options?: PasskeyCreationOptions
+) => Promise<AuthResult>;
 type LoginWithPasskey = (identifier?: string | null) => Promise<AuthResult>;
 type DeviceSupportsPasskeys = () => Promise<boolean>;
 type AuthWithoutPasskey = (identifier: string) => Promise<string>;
@@ -195,10 +208,14 @@ class Passage {
    * @throws {PassageError} When user cancels operation, user already exists, app configuration was not done properly, etc.
    */
   registerWithPasskey: RegisterWithPasskey = async (
-    identifier: string
+    identifier: string,
+    options?: PasskeyCreationOptions
   ): Promise<AuthResult> => {
     try {
-      const result = await PassageReactNative.registerWithPasskey(identifier);
+      const result = await PassageReactNative.registerWithPasskey(
+        identifier,
+        options || null
+      );
       const parsedResult = JSON.parse(result);
       return parsedResult;
     } catch (error: any) {
@@ -220,7 +237,9 @@ class Passage {
     identifier?: string | null
   ): Promise<AuthResult> => {
     try {
-      const result = await PassageReactNative.loginWithPasskey(identifier || null);
+      const result = await PassageReactNative.loginWithPasskey(
+        identifier || null
+      );
       const parsedResult = JSON.parse(result);
       return parsedResult;
     } catch (error: any) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -146,7 +146,7 @@ export enum SocialConnection {
 }
 
 type RegisterWithPasskey = (identifier: string) => Promise<AuthResult>;
-type LoginWithPasskey = () => Promise<AuthResult>;
+type LoginWithPasskey = (identifier?: string | null) => Promise<AuthResult>;
 type DeviceSupportsPasskeys = () => Promise<boolean>;
 type AuthWithoutPasskey = (identifier: string) => Promise<string>;
 type OTPActivate = (otp: string, otpId: string) => Promise<AuthResult>;
@@ -212,12 +212,15 @@ class Passage {
    * NOTE: Both Android and iOS do NOT take a user identifier paramter when logging in with a passkey.
    * The operating systems both show all of the passkeys available for the user and your application.
    *
+   * @param {string | null} identifier email address / phone for user (optional)
    * @return {Promise<AuthResult>} a data object that includes a redirect URL and saves the authorization token and (optional) refresh token securely to device.
    * @throws {PassageError} When user cancels operation, user does not exist, app configuration was not done properly, etc.
    */
-  loginWithPasskey: LoginWithPasskey = async (): Promise<AuthResult> => {
+  loginWithPasskey: LoginWithPasskey = async (
+    identifier?: string | null
+  ): Promise<AuthResult> => {
     try {
-      const result = await PassageReactNative.loginWithPasskey();
+      const result = await PassageReactNative.loginWithPasskey(identifier || null);
       const parsedResult = JSON.parse(result);
       return parsedResult;
     } catch (error: any) {


### PR DESCRIPTION
# What's new

### Log in in with identifier
Developers can now provide an explicit identifier to `loginWithPasskey`.

### Authenticator Attachments
Developers can now set `PasskeyCreationOptions` when calling passage.registerWithPasskey.
This new object contains one property called authenticatorAttachments which provides developers with more granular control of their users' passkey creation experience.
You can learn more about authenticator attachments in the [WebAuthn spec](https://w3c.github.io/webauthn/#dictionary-authenticatorSelection).

# Example code
```typescript
// Log in with identifier
// User will only be shown passkeys with that identifier for your app.
await passage.loginWithPasskey("name@email.com");

// Log in without identifier
// User will be shown all passkeys available to them for your app, potentially showing multiple identifiers.
await passage.loginWithPasskey();

// Register with options example
// Give user option to register with a physical security key or another mobile device
const options: PasskeyCreationOptions = {
    authenticatorAttachment: AuthenticatorAttachment.CrossPlatform
};
await passage.registerWithPasskey("name@email.com", options);

// Register without options
// Authenticator attachment will default to "platform", same as before.
await passage.registerWithPasskey("name@email.com")
```

# User experience
Example UI for "cross-platform" or "any" authenticator attachment option.
<img src="https://github.com/passageidentity/passage-ios/assets/16176400/25a9598a-6641-4911-8bcc-3b5284f3f95d" width="550"/>
