### PR TITLE
Fix ios passkey register error handling

### DIFF
--- a/passage-react-native.podspec
+++ b/passage-react-native.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Core"
 
-  s.dependency 'PassageSwift', '1.0.1'
+  s.dependency 'PassageSwift', '1.0.2'
   s.platform = :ios, '16.0'
 
   # Don't install the dependencies when we run `pod install` in the old architecture.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## What's New?

If iOS app configuration was not done properly and a user tries to register with a passkey, an error was NOT being thrown, only logged. This is now fixed.

## Screenshots (if appropriate):
In the example RN app screenshot below, app was not configured correctly and SDK now correctly throws an error.
<img src="https://github.com/user-attachments/assets/c2b6ed09-4520-43c0-a248-1549e7c74a27" alt="Simulator Screenshot - iPhone 16 - 2024-11-06 at 11 37 23" width="300"/>



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have manually tested my code thoroughly
- [x] I have added/updated inline documentation for public facing interfaces if relevant
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing integration and unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
